### PR TITLE
Set ISR and API revalidation to 60 seconds

### DIFF
--- a/src/app/[locale]/_util/getHeatIndexes.ts
+++ b/src/app/[locale]/_util/getHeatIndexes.ts
@@ -25,7 +25,7 @@ export async function getHeatIndexes(
       try {
         const response = await fetch(
           `${HEAT_INDEX_API_URL}/${spot.heatIndexId}`,
-          { cache: "no-store" }
+          { next: { revalidate: 60 } }
         );
         if (!response.ok) return [spot.id, { status: "error" }];
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -74,4 +74,4 @@ export default async function Home({ params }: HomeProps) {
 }
 
 // 最後の生成から1分以後にアクセスされた場合は再生成する
-export const revalidate = 10;
+export const revalidate = 60;


### PR DESCRIPTION
## Summary
- Set the home page ISR revalidation to 60 seconds
- Set heat-index API fetch caching to 60 seconds
- Replace no-store fetching so the route can be statically generated

## Validation
- npm run typecheck
- npm run lint
- npm run build