### PR TITLE
Add extremely dangerous heat index label

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -16,6 +16,7 @@
       "empty": "No data"
     },
     "heatIndexLevels": {
+      "extremely_dangerous": "Extremely dangerous",
       "dangerous": "Danger",
       "danger": "Danger",
       "severe_alert": "Severe alert",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -16,6 +16,7 @@
       "empty": "データなし"
     },
     "heatIndexLevels": {
+      "extremely_dangerous": "極めて危険",
       "dangerous": "危険",
       "danger": "危険",
       "severe_alert": "厳重警戒",

--- a/src/app/[locale]/_components/SpotCard/HeatIndex.tsx
+++ b/src/app/[locale]/_components/SpotCard/HeatIndex.tsx
@@ -4,8 +4,10 @@ import { useTranslations } from "next-intl";
 import type { HeatIndex as HeatIndexValue } from "../../_util/getHeatIndexes";
 
 const levelClassName: Record<string, string> = {
-  // Yahoo! heatstroke levels: dangerous, severe_alert, alert, caution, safe.
+  // Yahoo! heatstroke levels: extremely_dangerous, dangerous, severe_alert,
+  // alert, caution, safe.
   // Keep `danger` as an alias for compatibility with older API data.
+  extremely_dangerous: "bg-[#928] text-white border-[#928]",
   dangerous: "bg-[#ed002f] text-white border-[#ed002f]",
   danger: "bg-[#ed002f] text-white border-[#ed002f]",
   severe_alert: "bg-[#ff9500] text-black border-[#ff9500]",


### PR DESCRIPTION
Adds English and Japanese translations and styling for the extremely dangerous heat index level.

Checks: npm run lint; npm run typecheck